### PR TITLE
Modularize webassets

### DIFF
--- a/ckanext/resourcesfilter/templates/package/snippets/resources_filter_webassets.html
+++ b/ckanext/resourcesfilter/templates/package/snippets/resources_filter_webassets.html
@@ -1,4 +1,3 @@
-{% asset 'resourcesfilter/resources-list-css' %}
 {% asset 'resourcesfilter/resources-list' %}
 {% set read_url = h.url_for("resource.read", id=pkg.name, resource_id="__resource_id__") %}
 {% set edit_url = h.url_for("resource.edit", id=pkg.name, resource_id="__resource_id__") %}

--- a/ckanext/resourcesfilter/webassets/webassets.yml
+++ b/ckanext/resourcesfilter/webassets/webassets.yml
@@ -3,11 +3,18 @@ resources-list-css:
     - vendor/pagination.css
     - modules/resources-list.css
 
-resources-list:
+resources-list-vendor:
   contents:
     - vendor/pagination.js
     - vendor/mustache.js
-    - modules/resources-list.js
   extra:
     preload:
         - base/main
+
+resources-list:
+  contents:
+    - modules/resources-list.js
+  extra:
+    preload:
+        - resourcesfilter/resources-list-vendor
+        - resourcesfilter/resources-list-css


### PR DESCRIPTION
Currently the `resourcefilter/resource-filter` contains both vendor and the extension javascript code. 

Since other extensions may want to override `resources-list.js` to add custom logic is better to keep it separated to avoid loading it twice (since other extensions may also need to call `resourcefilter/resource-filter` to add vendor's webasset).

With this changes, other extensions can create their custom `resource-list.js` and include css and vendor files in different calls like this:
```
    {% asset 'my_extension/resources-list' %}
    {% asset 'resourcesfilter/resources-list-css' %}
    {% asset 'resourcesfilter/resources-list-vendor' %}
```

(or add css and vendor the their own webasset preload option)